### PR TITLE
Upgrade tgis adapter to fix Lora/QLora inferencing

### DIFF
--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -5,7 +5,7 @@ ARG VLLM_VERSION="v0.10.0.2"
 # Default ROCm ARCHes to build vLLM for.
 ARG PYTORCH_ROCM_ARCH="gfx908;gfx90a;gfx942;gfx1100"
 ARG MAX_JOBS=12
-ARG VLLM_TGIS_ADAPTER_VERSION=0.8.0
+ARG VLLM_TGIS_ADAPTER_VERSION=0.8.1
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:${BASE_UBI_IMAGE_TAG} AS base
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHOAIENG-35040

vllm-tgis-adapter is updated to 0.8.1 to work with vllm v0.10.0 (RHOAI 2.24).
Fixes Lora adapter crash
``Inference on LoRA-tuned model fails with error: 'str' object has no attribute 'lora_name' ``

Also addresses https://issues.redhat.com/browse/INFERENG-2231 for 2.24