### PR TITLE
upgrade tgis adapter to 0.9.0.post1

### DIFF
--- a/Dockerfile.konflux.rocm
+++ b/Dockerfile.konflux.rocm
@@ -4,6 +4,14 @@ ARG RHAIIS_VERSION=3.2.1
 ## Base Layer ##################################################################
 FROM registry.redhat.io/rhaiis/vllm-rocm-rhel9:${RHAIIS_VERSION} as vllm-grpc-adapter
 
+ARG VLLM_TGIS_ADAPTER_VERSION="0.9.0.post1"
+USER root
+
+## Install vLLM-TGIS-Adapter ####################################################
+RUN pip install --no-cache --no-deps vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
+
+USER 1001
+
 ENV GRPC_PORT=8033 \
     PORT=8000 \
     # As an optimization, vLLM disables logprobs when using spec decoding by
@@ -12,7 +20,7 @@ ENV GRPC_PORT=8033 \
     # see: https://github.com/vllm-project/vllm/pull/6485
     DISABLE_LOGPROBS_DURING_SPEC_DECODING=false
 
-USER 2000
+
 ENTRYPOINT ["python3", "-m", "vllm_tgis_adapter", "--uvicorn-log-level=warning"]
 
 LABEL name="rhoai/odh-vllm-rocm-rhel9" \
@@ -22,3 +30,4 @@ LABEL name="rhoai/odh-vllm-rocm-rhel9" \
       description="GPU-accelerated vLLM build using AMD ROCm for high-performance inference." \
       summary="GPU-accelerated vLLM build using AMD ROCm for high-performance inference." \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+      


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-35040
Upgrade vllm-tgis-adapter to 0.9.0.post1 to fix
ModuleNotFoundError: No module named 'vllm.model_executor.guided_decoding'